### PR TITLE
[NZPMC-041] Migrate answer ID to unique ID

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -10,7 +10,7 @@ import {
     getOptionByQuestionID,
     addQuestionOption,
     editQuestionOption,
-    upsertQuestionAnswer,
+    insertQuestionAnswer,
 } from './option'
 import { getAllQuizzes, getQuiz, addQuiz, editQuiz } from './quiz'
 import { getUser, getAllUsers, addUser, editUser } from './user'
@@ -55,7 +55,7 @@ export {
     editQuiz,
     addQuestionOption,
     editQuestionOption,
-    upsertQuestionAnswer,
+    insertQuestionAnswer,
     submitUserQuizQuestions,
     setUserQuizScore
 }

--- a/controllers/option.js
+++ b/controllers/option.js
@@ -63,14 +63,13 @@ const editQuestionOption = async (question, id, o) => {
     return packOption(option)
 }
 
-const upsertQuestionAnswer = async (question, o) => {
+const insertQuestionAnswer = async (question, o) => {
     let option, created
     if (!question.answer || !question.answer.ref) {
         option = Option.init()
         created = new Date()
-        option.id = question.id
     } else {
-        option = await Option.collection.get({ id: question.id })
+        option = await Option.collection.get({ id: question.answer.id })
         created = option.created.toDate()
     }
 
@@ -78,8 +77,9 @@ const upsertQuestionAnswer = async (question, o) => {
     option.created = created
     option.modified = new Date()
 
-    await option.upsert()
+    await option.save()
 
+    // update question with answer
     const q = await Question.collection.get({ key: question.key })
     q.answer = option.key
     q.created = q.created.toDate()
@@ -96,5 +96,5 @@ export {
     getOptionByQuestionID,
     addQuestionOption,
     editQuestionOption,
-    upsertQuestionAnswer,
+    insertQuestionAnswer,
 }

--- a/controllers/question.js
+++ b/controllers/question.js
@@ -1,4 +1,4 @@
-import { Question } from '../models'
+import { Question, Option } from '../models'
 
 const packQuestion = (question) => {
     return {
@@ -40,12 +40,16 @@ const addQuestion = async (quiz, q, imageURI, numOfAnswers, topics) => {
     question.created = new Date()
     question.modified = new Date()
 
+    const answer = Answer.init()
+    answer.option = ""
+    question.answer = answer.key
+
     await question.save()
 
     return packQuestion(question)
 }
 
-const editQuestion = async (quiz, id, q, imageURI, numOfAnswers, topics) => {
+const editQuestion = async (quiz, id, q, imageURI, numOfAnswers, answer, topics) => {
     const question = await Question.collection.get({key: quiz.key+"/Question/"+id})
 
     question.question = q ? q : question.question
@@ -54,10 +58,7 @@ const editQuestion = async (quiz, id, q, imageURI, numOfAnswers, topics) => {
     question.topics = topics ? topics : question.topics
     question.modified = new Date()
     question.created = question.created.toDate()
-
-    question.answer = question.answer.ref
-        ? undefined
-        : (await question.answer.get()).key
+    question.answer = answer ? answer : (await question.answer.get()).key
 
     await question.update()
 

--- a/resolvers/options.js
+++ b/resolvers/options.js
@@ -3,7 +3,7 @@ import {
     getQuiz,
     addQuestionOption,
     editQuestionOption,
-    upsertQuestionAnswer,
+    insertQuestionAnswer,
 } from '../controllers'
 
 const resolvers = {
@@ -34,7 +34,7 @@ const resolvers = {
 
             const question = await getQuestion(quiz, questionID)
 
-            return await upsertQuestionAnswer(question, option)
+            return await insertQuestionAnswer(question, option)
         },
     },
 }

--- a/resolvers/userQuizzes.js
+++ b/resolvers/userQuizzes.js
@@ -97,7 +97,9 @@ const resolvers = {
             const userQuiz = await getUserQuiz(userQuizID)
             const quiz = await userQuiz.quizObj.get()
             const userAnswers = await getUserAnswerIDs(userQuiz)
-            const correctAnswers = (await getQuestions(quiz)).map((question) => question.id)
+            const correctAnswers = await Promise.all((await getQuestions(quiz)).map(async (question) => {
+                return (await question.answerObj.get()).id
+            }))
 
             // update UserQuiz
             return await submitUserQuizQuestions(userQuizID, userAnswers, correctAnswers)


### PR DESCRIPTION
**Issue**

Issue: answerID == questionID

Risk - hackable.

**Solution**

Changed question.answer to point to an answer object with a unique id so answerID != questionID, most of my time with this PR was manually updating the database with the new structures using the queries lol

**Reviewers**
CZ, Will