### PR TITLE
[NZPMC-059] Remove score field in userQuiz Query

### DIFF
--- a/resolvers/userQuizzes.js
+++ b/resolvers/userQuizzes.js
@@ -71,7 +71,12 @@ const resolvers = {
             const userQuiz = await getUserQuiz(args.quizID)
             const user = await userQuiz.userObj.get()
 
-            if (user.id !== context.user.uid) throw new AuthenticationError()
+            if (user.id !== context.user.uid && !context.user.admin) throw new AuthenticationError()
+
+            if (!context.user.admin) {
+                userQuiz.score = null
+            }
+
             return userQuiz
         },
     },


### PR DESCRIPTION
**Issue**

Users could access the score when performing a userQuiz query. 

**Solution**

Added authentication so only admins can see the final score on a userQuiz object

**Risk**

Low
Could break existing userQuiz score code 

**Reviewers**

CZ, Will 